### PR TITLE
Add support to choose specific locale

### DIFF
--- a/current_time.py
+++ b/current_time.py
@@ -1,4 +1,5 @@
 import datetime
+import locale
 
 def meta(ctx, cmdline):
     action = ctx.new_action()
@@ -6,6 +7,16 @@ def meta(ctx, cmdline):
     return action
 
 def time(formatting):
+    fmt, *new_locale = formatting.split(':')
+
+    current_locale = locale.getlocale()
+
+    if new_locale:
+        locale.setlocale(locale.LC_ALL, new_locale[0])
+
     now = datetime.datetime.now()
-    formatted = now.strftime(formatting)
+    formatted = now.strftime(fmt)
+
+    locale.setlocale(locale.LC_ALL, current_locale)
+
     return(formatted)


### PR DESCRIPTION
With this PR, the meta can accept a second parameter that should specify the locale desired for the output. For example:
```
>>> # "TKA*ET": "{:time:%A, %d %B, %Y}"
>>> # Sunday, 25 April, 2021
>>> # "TKA*/TUPL": "{:time:%A, %d %B, %Y:de_DE}"
>>> # Sonntag, 25 April, 2021
>>> # "TP*E/KHA": "{:time:%A, %d %B, %Y:es_ES}"
>>> #  domingo, 25 abril, 2021
```