### PR TITLE
Define ">>" for locale separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Install from the Plover plugins manager.
 | `"TKA*ET": "{:time:%A, %d %B, %Y},"` | Output current date in a nice human readable format. |
 | `"PWRAEBG": "\n(break started: {:time:%H:%M:%S}{^})\n",` | Note that a break has started and at what time. |
 | `"PWRA*EBG": "\n(break ended: {:time:%H:%M:%S}{^})\n",` | Note that the break has ended and at what time. |
+
+Optionally, you can define a locale to get more specific output. The locale should be available on your system, and it can be specified after the separator `>>`, like this:
+
+| Dictionary Entry | Description |
+| ---- | ---- |
+| `"TKA*/TUPL": "{:time:%A, %d %B, %Y>>de_DE}",` | Output current date in german. | 
+| `"TP*E/KHA": "{:time:%A, %d %B, %Y>>es_ES}",` | Output current date in spanish. | 

--- a/current_time.py
+++ b/current_time.py
@@ -7,7 +7,7 @@ def meta(ctx, cmdline):
     return action
 
 def time(formatting):
-    fmt, *new_locale = formatting.split(':')
+    fmt, *new_locale = formatting.split('>>')
 
     current_locale = locale.getlocale()
 


### PR DESCRIPTION
Using ":" as a separator for locale messes the formatting when you have other colons, for example in `{:time:%H:%M:%S}`.

With this PR, translation should be:
```
>>> # "TKA*ET": "{:time:%A, %d %B, %Y}"
>>> # Sunday, 25 April, 2021
>>> # "TKA*/TUPL": "{:time:%A, %d %B, %Y>>de_DE}"
>>> # Sonntag, 25 April, 2021
>>> # "TP*E/KHA": "{:time:%A, %d %B, %Y>>es_ES}"
>>> #  domingo, 25 abril, 2021
```